### PR TITLE
fix: Use newer task execution handler to avoid deprecated warning in …

### DIFF
--- a/src/Tasks/Wait/task.json
+++ b/src/Tasks/Wait/task.json
@@ -40,7 +40,7 @@
     }
   ],
   "execution": {
-    "PowerShell": {
+    "PowerShell3": {
       "target": "$(currentDirectory)/Code/Wait.ps1",
       "workingDirectory": "$(currentDirectory)"
     }


### PR DESCRIPTION
…Azure DevOps. Hopefully will fix Issue #2 .